### PR TITLE
Added stickyness to tweet items button. 

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -35,3 +35,5 @@ raix:eventddp
 service-configuration
 mizzao:autocomplete
 fastclick
+jamiter:pluralize
+bambattajb:sticky

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -6,6 +6,7 @@ alethes:pages@1.8.4
 autoupdate@1.2.4
 babel-compiler@5.8.24_1
 babel-runtime@0.1.4
+bambattajb:sticky@1.1.1
 base64@1.0.4
 binary-heap@1.0.4
 blaze@2.1.3
@@ -47,6 +48,7 @@ iron:location@1.0.11
 iron:middleware-stack@1.0.11
 iron:router@1.0.12
 iron:url@1.0.11
+jamiter:pluralize@1.0.2
 jquery@1.11.4
 lablancas:twitter@0.0.1
 launch-screen@1.0.4

--- a/client/css/style.less
+++ b/client/css/style.less
@@ -37,6 +37,9 @@ div.panel {
           width: 19px;
         }
       }
+      a#tweet-items{
+        z-index: 100;
+      }
     }
     table {
       th {

--- a/client/views/pages/home.html
+++ b/client/views/pages/home.html
@@ -71,10 +71,9 @@
                 <p>Pending Items: {{pendingItems}}</p>
             </div>
             <div class="form-group">
-              <p>Selected Entries: {{ selectedItemsCount }}</p>
               <a id="tweet-items" href="#"
               class="btn btn-default btn-lg btn-block btn-success btn-raised"><i
-              class="fa fa-twitter"></i> Tweet</a>
+              class="fa fa-twitter"></i> {{ selectedItemsCount }} {{ selectedItemsToTweet }}</a>
             </div>
           </div>
         </div>

--- a/client/views/pages/home.js
+++ b/client/views/pages/home.js
@@ -142,6 +142,9 @@ Template.home.helpers({
   },
   filteredByHashtagsOrMentions: function () {
     return filteredByHashtagsOrMentions.get();
+  },
+  selectedItemsToTweet: function(){
+    return pluralize("tweet", parseInt(selectedItemsCount.get(), 10));
   }
 });
 
@@ -372,6 +375,9 @@ Template.home.onRendered(function () {
   $(window).resize(function(){
     adjustPager();
   });
+
+  $("#tweet-items").sticky({topSpacing:60});
+
 });
 
 Template.item.helpers({


### PR DESCRIPTION
The **Tweet** button now sticks to the top of the window when the user scrolls past it. This allows the user to easily tweet selected items. Additionally the label for the button now shows the **count of total items selected**. Closes #44
